### PR TITLE
fix: override `log-word-wrap=false` in `LogGraph` to prevent parser breakage

### DIFF
--- a/internal/runner/local.go
+++ b/internal/runner/local.go
@@ -36,6 +36,25 @@ func NewLocalRunner(repoDir string) *LocalRunner {
 	return &LocalRunner{Binary: "jj", RepoDir: repoDir}
 }
 
+// jjNoWrap disables ui.log-word-wrap globally for jj invocations. User config
+// with log-word-wrap=true splits single-line template output across graph
+// lines — every parser in internal/jj (LogGraph, OpLog, Divergence,
+// StaleImmutable, GetDescription, …) splits on \n and either drops rows with
+// the wrong field count or injects spurious newlines into editor prefill.
+// Applied once at the runner boundary so per-builder overrides aren't needed.
+const jjNoWrap = "--config=ui.log-word-wrap=false"
+
+// prependJJFlags injects jjNoWrap when Binary resolves to jj. Skipped for
+// RunRaw paths (gh, etc.) and for SSHRunner's internal ssh invocations (the
+// flag is prepended to jj args inside wrapArgs before the ssh wrap).
+// filepath.Base so absolute paths (`/usr/local/bin/jj`) match too.
+func (r *LocalRunner) prependJJFlags(args []string) []string {
+	if filepath.Base(r.Binary) != "jj" {
+		return args
+	}
+	return append([]string{jjNoWrap}, args...)
+}
+
 // waitDelay force-closes pipes when a grandchild process (SSH ControlMaster
 // mux master) inherits them — ctx expiry kills the direct child, but Wait()
 // blocks in awaitGoroutines until the pipe-copier sees EOF. Applied to every
@@ -86,6 +105,7 @@ func (r *LocalRunner) RunWithInput(ctx context.Context, args []string, stdin str
 // on success. On non-zero exit, stderr is baked into the error message
 // (stdout/stderr are nil).
 func (r *LocalRunner) runSeparate(ctx context.Context, args []string, stdin string) ([]byte, []byte, error) {
+	args = r.prependJJFlags(args)
 	cmd := exec.CommandContext(ctx, r.Binary, args...)
 	cmd.Dir = r.RepoDir
 	cmd.WaitDelay = waitDelay
@@ -154,6 +174,7 @@ func (r *LocalRunner) RunForMutation(ctx context.Context, args []string, stdin s
 // queries shouldn't warn; if they did, mixing warnings into the byte stream
 // would corrupt it anyway).
 func (r *LocalRunner) ReadBytes(ctx context.Context, args []string) ([]byte, error) {
+	args = r.prependJJFlags(args)
 	cmd := exec.CommandContext(ctx, r.Binary, args...)
 	cmd.Dir = r.RepoDir
 	cmd.WaitDelay = waitDelay
@@ -222,6 +243,7 @@ func (r *LocalRunner) StreamCombined(ctx context.Context, args []string) (io.Rea
 }
 
 func (r *LocalRunner) stream(ctx context.Context, args []string, mergeStderr bool) (io.ReadCloser, error) {
+	args = r.prependJJFlags(args)
 	cmd := exec.CommandContext(ctx, r.Binary, args...)
 	cmd.Dir = r.RepoDir
 	// StdoutPipe case: the hang is in the CALLER's Scanner.Read (grandchild

--- a/internal/runner/local_test.go
+++ b/internal/runner/local_test.go
@@ -184,6 +184,24 @@ func TestLocalRunner_ReadBytes_ExitWithStderr(t *testing.T) {
 	assert.Contains(t, err.Error(), "oops")
 }
 
+func TestLocalRunner_prependJJFlags(t *testing.T) {
+	// jj binary → inject --config=ui.log-word-wrap=false at argv[0]. Every
+	// builder in internal/jj emits wrap-susceptible single-line templates;
+	// injecting once here keeps per-builder args clean.
+	jj := &LocalRunner{Binary: "jj"}
+	got := jj.prependJJFlags([]string{"log", "-r", "@"})
+	assert.Equal(t, []string{"--config=ui.log-word-wrap=false", "log", "-r", "@"}, got)
+
+	// Absolute path to jj must also match — users with non-PATH installs.
+	abs := &LocalRunner{Binary: "/usr/local/bin/jj"}
+	assert.Equal(t, []string{"--config=ui.log-word-wrap=false", "log"}, abs.prependJJFlags([]string{"log"}))
+
+	// Non-jj binary (RunRaw path for gh) → untouched. A jj flag in gh's argv
+	// would make gh error out.
+	gh := &LocalRunner{Binary: "gh"}
+	assert.Equal(t, []string{"pr", "list"}, gh.prependJJFlags([]string{"pr", "list"}))
+}
+
 // WriteFile symlink-escape tests — moved from handler tests when the check
 // migrated from handleFileWrite to LocalRunner.WriteFile (SSH-mode file-write
 // support). The handler does lexical validation; the runner owns filesystem

--- a/internal/runner/ssh.go
+++ b/internal/runner/ssh.go
@@ -37,7 +37,11 @@ func (r *SSHRunner) sshArgv(remoteCmd string) []string {
 }
 
 func (r *SSHRunner) wrapArgs(jjArgs []string) []string {
-	return r.sshArgv(fmt.Sprintf("jj -R %s %s", shellQuote(r.RepoPath), quoteAll(jjArgs)))
+	// See local.go:jjNoWrap — inject once at the runner boundary so every jj
+	// builder gets wrap-safe output. SSHRunner's inner local uses Binary="ssh",
+	// so local.go's prependJJFlags doesn't fire for this path.
+	withFlags := append([]string{jjNoWrap}, jjArgs...)
+	return r.sshArgv(fmt.Sprintf("jj -R %s %s", shellQuote(r.RepoPath), quoteAll(withFlags)))
 }
 
 func (r *SSHRunner) Run(ctx context.Context, args []string) ([]byte, error) {

--- a/internal/runner/ssh_test.go
+++ b/internal/runner/ssh_test.go
@@ -21,6 +21,17 @@ func TestSSHRunner_wrapArgs(t *testing.T) {
 	assert.Contains(t, got[n+1], "'log'")
 	assert.Contains(t, got[n+1], "'-r'")
 	assert.Contains(t, got[n+1], "'@'")
+	// jjNoWrap injected at the runner boundary so every jj command gets
+	// wrap-safe output without per-builder overrides.
+	assert.Contains(t, got[n+1], "'--config=ui.log-word-wrap=false'")
+}
+
+func TestSSHRunner_wrapRaw_NoJJFlagInjection(t *testing.T) {
+	// RunRaw is for non-jj binaries (gh). Prepending a jj flag would break
+	// argv — verify wrapRaw leaves it alone.
+	r := NewSSHRunner("user@host", "/home/user/repo")
+	got := r.wrapRaw([]string{"gh", "pr", "list"})
+	assert.NotContains(t, got[n+1], "log-word-wrap")
 }
 
 func TestSSHRunner_wrapRaw(t *testing.T) {


### PR DESCRIPTION
User config `ui.log-word-wrap = true` causes jj to split the single-line template output across multiple graph lines. The parser only extracts `\x1F`-delimited fields from the `_PREFIX:` node line — wrapped continuation lines are treated as connectors, losing description/bookmarks/parent IDs.


@chronologos this fixes description not showing with the log word wrap option enabled