### PR TITLE
ci: build E2E Fuzz binary with -tags embed (fixes appMounts)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -52,9 +52,14 @@ jobs:
           bombadil --version
 
       - name: Build lightjj
+        # -tags embed is REQUIRED: without it `go build` produces the stub
+        # binary (frontend_stub.go, //go:build !embed) that serves a static
+        # "frontend not bundled" help page instead of the SPA — bombadil then
+        # fuzzes an empty page and appMounts fails forever. The build-tag split
+        # landed in v1.24.1; release.yml got the tag, this workflow didn't.
         run: |
           (cd frontend && pnpm install --frozen-lockfile && pnpm run build)
-          go build ./cmd/lightjj
+          go build -tags embed ./cmd/lightjj
 
       - name: Typecheck spec
         working-directory: e2e/bombadil

--- a/e2e/bombadil/run.sh
+++ b/e2e/bombadil/run.sh
@@ -53,6 +53,21 @@ for _ in $(seq 50); do
   sleep 0.1
 done
 
+# Defensive: pre-warm the API before fuzzing. Polling `/` above only confirms
+# the HTTP server has bound — it doesn't run the first (cold) `jj log`
+# subprocess. bombadil's time-windowed liveness properties (e.g. appMounts'
+# `eventually(...).within(5,"seconds")`) advance on a per-captured-state clock,
+# so warming the cold path here keeps a slow first `jj log` (+ op-id seed) from
+# eating into that budget on a contended runner. The API is tab-scoped — the
+# `-R` repo mounts as tab "0", so /tab/0/api/log is the real log route
+# (bare /api/log 404s; only /api/config + /api/state live at the root). Not
+# load-bearing for the stub-binary bug this directory's history documents
+# (missing `-tags embed` in e2e.yml) — just removes a cold-start flake class.
+for _ in $(seq 50); do
+  curl -sf "http://localhost:$PORT/tab/0/api/log" >/dev/null && break
+  sleep 0.1
+done
+
 # --- bombadil ------------------------------------------------------------
 rm -rf "$OUT"
 HEADLESS_FLAG="--headless"

--- a/e2e/bombadil/spec.ts
+++ b/e2e/bombadil/spec.ts
@@ -113,7 +113,11 @@ const focusInInput = extract((s) => {
 //
 // revisionCount>0 proves both Svelte-mount AND API round-trip; a bare
 // `.panel` check would miss the server-side-broken case. 5s is generous
-// for a 12-commit localhost fixture.
+// for a 12-commit localhost fixture — provided the binary actually serves
+// the SPA. The May–June 2026 "appMounts timed out" runs were NOT this
+// property being too tight: e2e.yml built the stub binary (missing
+// `-tags embed`), so the page was a static help stub with zero rows. The
+// fix is in the workflow, not this deadline.
 export const appMounts = eventually(() =>
   revisionCount.current > 0
 ).within(5, "seconds");


### PR DESCRIPTION
## TL;DR

E2E Fuzz has been red since ~v1.24.1 because the workflow built the **stub** binary (missing `-tags embed`) and bombadil was fuzzing a static "frontend not bundled" help page. One-line fix in the build step. **Not a flake — deterministic.**

## Evidence (from the failed run's trace artifact)

- All 225 captured states: `revisionCount: 0`, `responseStatus: 200`, **zero** console errors, **zero** uncaught exceptions.
- Screenshots show the **`lightjj — frontend not bundled`** stub page (`frontend_stub.go`).

## Root cause

`e2e.yml` built with `go build ./cmd/lightjj` — no `-tags embed`. The build-tag split landed in **v1.24.1**:
- `frontend_stub.go` (`//go:build !embed`) → serves a static help page
- `frontend_embed.go` (`//go:build embed`) → serves the SPA

`release.yml` got `-tags embed`; this workflow didn't. So every run since v1.24.1 fuzzed an empty stub and `appMounts` (`eventually revisionCount > 0`) correctly failed. The April runs passed because, pre-split, plain `go build` embedded the frontend.

## Fix

- **`e2e.yml`**: `go build ./cmd/lightjj` → `go build -tags embed ./cmd/lightjj`. Verified locally: embed binary serves `<div id=app>` + module script and `/tab/0/api/log` returns rows; stub serves "frontend not bundled".
- **`run.sh`** (defensive, not load-bearing): pre-warm the cold `jj log` via `/tab/0/api/log` (the API is tab-scoped — bare `/api/log` 404s) before launching bombadil, so a slow first subprocess can't eat a time-windowed liveness budget on a contended runner.
- **`spec.ts`**: `appMounts` stays at **5s** (an earlier 30s bump was reverted once the real cause was found) — history shows 5s is correct once the SPA is actually served; comment updated to point at the workflow fix.

Validated: `bash -n run.sh`, `tsc --noEmit`, workflow YAML parse — all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)