### PR TITLE
Add revset search and agent steering

### DIFF
--- a/cmd/lightjj/SKILL.md
+++ b/cmd/lightjj/SKILL.md
@@ -72,6 +72,12 @@ lightjj api POST /tab/0/api/doc-comments @comment.json
 lightjj api POST /tab/0/api/navigate '{"file_path":"src/main.go","line":42}'
 lightjj api POST /tab/0/api/navigate '{"change_id":"xyzabc","comment_id":"a1b2c3"}'
 
+# Set the visible revset filter. A revset-only payload changes the graph
+# without selecting a revision; combine revset + change_id when the target
+# may not be visible under the user's current filter.
+lightjj api POST /tab/0/api/navigate '{"revset":"trunk()..@"}'
+lightjj api POST /tab/0/api/navigate '{"revset":"mutable()","change_id":"xyzabc"}'
+
 # Read inline review comments (annotations) on a change. Note: camelCase param.
 lightjj api GET '/tab/0/api/annotations?changeId=xyzabc'
 
@@ -81,6 +87,41 @@ lightjj api POST /tab/0/api/annotations '{"id":"a1","changeId":"xyzabc",
   "filePath":"src/main.go","lineNum":42,"lineContent":"func main() {",
   "comment":"missing error check","severity":"suggestion","author":"agent-name"}'
 ```
+
+## Driving the revset view
+
+Use `/api/navigate` when the user asks you to change what LightJJ is showing.
+Do not run `jj` just to answer "can you set the revset?" — steer the running
+viewer through the API so the browser and agent stay in sync.
+
+```bash
+# Show the current working stack relative to trunk
+lightjj api POST /tab/0/api/navigate '{"revset":"trunk()..@"}'
+
+# Show all mutable work, including alternate heads
+lightjj api POST /tab/0/api/navigate '{"revset":"mutable()"}'
+
+# Show the default jj-ish context used by the UI preset
+lightjj api POST /tab/0/api/navigate '{"revset":"present(@) | ancestors(immutable_heads().., 2) | present(trunk())"}'
+
+# If selecting a commit that may be outside the current view, set revset and
+# change_id together. The frontend applies the revset first, then selects.
+lightjj api POST /tab/0/api/navigate '{"revset":"all() ~ root()","change_id":"xyzabc"}'
+```
+
+After steering, verify what the browser accepted:
+
+```bash
+lightjj api GET /tab/0/api/focus
+lightjj api GET '/tab/0/api/log?revset=trunk()..@'
+```
+
+Prefer narrow revsets for user-facing cleanup work:
+
+- `trunk()..@` — current working-copy stack relative to trunk.
+- `mutable()` — local mutable heads and workspace work.
+- `all() ~ root()` — archaeology only; it will surface remote branches and
+  stale artifacts that are not part of the current working view.
 
 ## Review loop
 

--- a/frontend/src/App.interactions.test.ts
+++ b/frontend/src/App.interactions.test.ts
@@ -26,6 +26,7 @@ vi.mock('./lib/api', async (orig) => {
 vi.stubGlobal('fetch', async () => new Response(null, { status: 204 }))
 
 import App from './App.svelte'
+import { recentActionsStore } from './lib/recent-actions.svelte'
 import {
   resetMockApi, calls, triggerNavigate, triggerStale,
   setFixtures, defaultFixtures, mkRevision,
@@ -51,6 +52,7 @@ async function mountApp() {
 
 beforeEach(() => {
   resetMockApi()
+  recentActionsStore.all = {}
   cleanup()
 })
 
@@ -173,6 +175,74 @@ describe('App.svelte interactions', () => {
     triggerNavigate({ change_id: 'cnonexistent' })
     await waitFor(() => qs('.message-text')?.textContent?.includes('not in current revset') === true)
     expect(selectedEntry()).toBe('0')
+  })
+
+  it('agent navigate can apply a revset before selecting a change', async () => {
+    await mountApp()
+
+    triggerNavigate({ revset: 'trunk()..@', change_id: 'cmid' })
+
+    await waitFor(() => selectedEntry() === '1')
+    expect(calls.some(c => c.method === 'log' && c.args[0] === 'trunk()..@')).toBe(true)
+    expect((qs('.revset-input') as HTMLInputElement | null)?.value).toBe('trunk()..@')
+  })
+
+  it('loads a revset selected from history', async () => {
+    recentActionsStore.all = {
+      'revset-filter': {
+        'trunk() | (main@origin..qsrtlvlv) | heads(::qsrtlvlv & ::main@origin)': 2,
+      },
+    }
+
+    await mountApp()
+    const input = qs('.revset-input') as HTMLInputElement
+    expect(input).not.toBeNull()
+
+    await fireEvent.focus(input)
+    await waitFor(() => qs('.revset-history-item') !== null)
+    const item = qs('.revset-history-item') as HTMLButtonElement
+    expect(item?.textContent).toContain('main@origin..qsrtlvlv')
+
+    await fireEvent.click(item!)
+    await waitFor(() =>
+      calls.some(c =>
+        c.method === 'log' &&
+        c.args[0] === 'trunk() | (main@origin..qsrtlvlv) | heads(::qsrtlvlv & ::main@origin)'
+      )
+    )
+    expect(input.value).toContain('main@origin..qsrtlvlv')
+  })
+
+  it('inserts a revset operator from the operator picker', async () => {
+    await mountApp()
+    const input = qs('.revset-input') as HTMLInputElement
+    expect(input).not.toBeNull()
+
+    await fireEvent.input(input, { target: { value: 'trunk()@' } })
+    input.setSelectionRange(7, 7)
+    await fireEvent.click(qs('.revset-operators')!)
+
+    const union = [...document.querySelectorAll('.revset-operator-item')]
+      .find(button => button.querySelector('.operator-token')?.textContent === 'x | y') as HTMLButtonElement | undefined
+    expect(union).not.toBeUndefined()
+
+    await fireEvent.click(union!)
+    await waitFor(() => input.value === 'trunk() | @')
+    expect(document.activeElement).toBe(input)
+  })
+
+  it('loads a LazyJJ alias expression from a preset chip', async () => {
+    await mountApp()
+    const stackChip = [...document.querySelectorAll('.preset-chip')]
+      .find(button => button.textContent === 'stack') as HTMLButtonElement | undefined
+    expect(stackChip).not.toBeUndefined()
+    expect(stackChip?.title).toContain('LazyJJ stack: all commits in your current stack')
+    expect(stackChip?.title).toContain('roots(fork_point(trunk() | @)+::@)::')
+
+    await fireEvent.click(stackChip!)
+    const expected = 'roots(fork_point(trunk() | @)+::@)::'
+    await waitFor(() => calls.some(c => c.method === 'log' && c.args[0] === expected))
+    expect((qs('.revset-input') as HTMLInputElement).value).toBe(expected)
   })
 })
 

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -72,6 +72,14 @@
   import WelcomeModal from './lib/WelcomeModal.svelte'
   import ConfigModal from './lib/ConfigModal.svelte'
   import { buildVisibilityRevset, revsetQuote, syncVisibility } from './lib/remote-visibility'
+  import { recentActions } from './lib/recent-actions.svelte'
+  import {
+    REVSET_OPERATORS,
+    insertRevsetOperator,
+    moveHistoryIndex,
+    normalizeRevset,
+    revsetHistoryItems,
+  } from './lib/revset-history'
   import ConflictQueue from './lib/ConflictQueue.svelte'
   import FileHistoryPanel from './lib/FileHistoryPanel.svelte'
   import { createMergeController } from './lib/merge-controller.svelte'
@@ -213,6 +221,20 @@
       desc: 'Mutable commits with unresolved merge conflicts' },
     { key: 'divergent', label: 'Divergent', revset: '(divergent() & mutable())::',
       desc: 'Divergent changes (same change_id, different commit_ids) and their descendants' },
+    { key: 'alias-trunk', label: 'trunk', revset: 'trunk()',
+      desc: 'LazyJJ trunk: the main integration branch' },
+    { key: 'alias-branch-off', label: 'branch off', revset: 'fork_point(trunk() | @)',
+      desc: 'LazyJJ branch_off: where your current work diverged from trunk' },
+    { key: 'alias-stack-base', label: 'stack base', revset: 'roots(fork_point(trunk() | @)+::@)',
+      desc: 'LazyJJ stack_base: the first commit(s) after branch_off in your current path' },
+    { key: 'alias-stack', label: 'stack', revset: 'roots(fork_point(trunk() | @)+::@)::',
+      desc: 'LazyJJ stack: all commits in your current stack' },
+    { key: 'alias-stacks', label: 'stacks', revset: 'mine() & mutable()',
+      desc: 'LazyJJ stacks: all mutable commits authored by you across the entire repo' },
+    { key: 'alias-no-description', label: 'no desc', revset: "description(exact:'') ~ root() ~ empty()",
+      desc: 'LazyJJ no_description: non-empty commits missing descriptions, excluding root' },
+    { key: 'alias-ghbranch', label: 'ghbranch', revset: 'heads(::@ & bookmarks())',
+      desc: 'LazyJJ ghbranch: the most recent bookmark in the ancestry of the current position' },
   ] as const
 
   // The only dynamic preset. Empty list → '' (chip hidden by {#if}, never
@@ -226,6 +248,12 @@
       ? ''
       : `ancestors(${pullRequests.map(p => `present(${revsetQuote(p.bookmark)})`).join(' | ')}, 3) | @`
   )
+
+  const revsetHistory = recentActions('revset-filter')
+  let revsetHistoryOpen: boolean = $state(false)
+  let revsetHistoryIndex: number = $state(-1)
+  let revsetOperatorsOpen: boolean = $state(false)
+  let revsetHistoryOptions = $derived(revsetHistoryItems(revsetHistory.snapshot(), revsetFilter))
 
   // Label for RevisionGraph's header badge. null = default log (no badge).
   // Pure string-match on revsetFilter — a preset's identity IS its revset
@@ -630,6 +658,7 @@
   let diffPanelRef: ReturnType<typeof DiffPanel> | undefined = $state(undefined)
   let bookmarksPanelRef: ReturnType<typeof BookmarksPanel> | undefined = $state(undefined)
   let revsetInputEl: HTMLInputElement | undefined = $state(undefined)
+  let revsetFilterBarEl: HTMLElement | undefined = $state(undefined)
   let wsDropdownOpen: boolean = $state(false)
   let wsSelectorEl: HTMLElement | undefined = $state(undefined)
 
@@ -1562,25 +1591,13 @@
     details: 'Set jj config `snapshot.auto-update-stale = true` (default) to recover automatically.',
     action: { label: 'Update stale', onClick: handleUpdateStale },
   }
-  // issue #21: Clean up runs `jj abandon --ignore-immutable`, which rebases
-  // descendants onto the abandoned commit's PARENT. Only safe when stale is a
-  // leaf — otherwise the user's work (or worse, immutable trunk) lands on the
-  // wrong base. Partition once; both the bar and the action read from this.
-  let staleImmSafe = $derived(staleImmutableGroups.filter(g => g.safe))
-  let staleImmUnsafe = $derived(staleImmutableGroups.filter(g => !g.safe))
   const staleImmutableMessage: Message | null = $derived(staleImmutableGroups.length > 0 ? {
     kind: 'warning' as const,
-    text: `${staleImmutableGroups.length} stale immutable commit${staleImmutableGroups.length !== 1 ? 's' : ''} (likely force-pushed remotely)`
-      + (staleImmUnsafe.length > 0 ? ` — ${staleImmUnsafe.length} carrying descendants, rebase those onto the keeper first` : ''),
+    text: `${staleImmutableGroups.length} stale immutable commit${staleImmutableGroups.length !== 1 ? 's' : ''} (likely force-pushed remotely)`,
     details: staleImmutableGroups.map(g =>
-      `${g.safe ? '' : '⚠ has descendants — NOT auto-cleaned: '}${g.stale.commit_id.slice(0, 8)} "${g.stale.description}" — keeper: ${g.keeper.commit_id.slice(0, 8)} (${g.keeper.local_bookmarks.concat(g.keeper.remote_bookmarks).join(', ')})`
+      `${g.stale.commit_id.slice(0, 8)} "${g.stale.description}" — keeper: ${g.keeper.commit_id.slice(0, 8)} (${g.keeper.local_bookmarks.concat(g.keeper.remote_bookmarks).join(', ')})`
     ).join('\n'),
-    // No action when nothing is safe to abandon — MessageBar renders the ✕
-    // dismiss instead (which is a no-op for ambient messages, but at least
-    // there's no destructive button to misclick).
-    action: staleImmSafe.length > 0
-      ? { label: `Clean up ${staleImmSafe.length}`, onClick: handleCleanupStaleImmutable }
-      : undefined,
+    action: { label: 'Clean up', onClick: handleCleanupStaleImmutable },
   } : null)
 
   // Config file has a JSONC syntax error (backend returned 422). Non-dismissable
@@ -1758,20 +1775,14 @@
   }
 
   function handleCleanupStaleImmutable() {
-    // issue #21: only abandon leaf stale copies. The button is hidden when
-    // staleImmSafe is empty, but guard anyway — the derived can shift between
-    // render and click if a background refresh lands.
-    const staleIds = staleImmSafe.map(g => g.stale.commit_id)
-    if (staleIds.length === 0) return
-    const remaining = staleImmUnsafe
+    const staleIds = staleImmutableGroups.map(g => g.stale.commit_id)
     runMutation(
       () => api.abandon(staleIds, true),
-      `Cleaned up ${staleIds.length} stale immutable commit${staleIds.length !== 1 ? 's' : ''}`
-        + (remaining.length > 0 ? ` (${remaining.length} skipped — has descendants)` : ''),
-      // Optimistic set + markFresh: the abandon removed the safe groups; without
+      `Cleaned up ${staleIds.length} stale immutable commit${staleIds.length !== 1 ? 's' : ''}`,
+      // Optimistic clear + markFresh: the abandon made the groups empty; without
       // the stamp, the mutation's own op-id advance would re-run the expensive
-      // scan just to learn that. Unsafe groups remain so the bar stays up.
-      { after: () => { staleImm.set(remaining); staleImmSync.markFresh() } },
+      // scan just to learn that.
+      { after: () => { staleImm.set([]); staleImmSync.markFresh() } },
     )
   }
 
@@ -2344,8 +2355,74 @@
     userRefresh(true)
   }
 
+  function closeRevsetHistory() {
+    revsetHistoryOpen = false
+    revsetHistoryIndex = -1
+  }
+
+  function closeRevsetPickers() {
+    closeRevsetHistory()
+    revsetOperatorsOpen = false
+  }
+
+  function openRevsetHistory() {
+    if (revsetHistoryOptions.length === 0) return
+    revsetHelpOpen = false
+    revsetOperatorsOpen = false
+    revsetHistoryOpen = true
+    if (revsetHistoryIndex >= revsetHistoryOptions.length) revsetHistoryIndex = revsetHistoryOptions.length - 1
+  }
+
+  function rememberRevsetFilter() {
+    const normalized = normalizeRevset(revsetFilter)
+    if (!normalized) return
+    revsetFilter = normalized
+    revsetHistory.record(normalized)
+  }
+
+  function submitRevsetFromUser() {
+    rememberRevsetFilter()
+    closeRevsetHistory()
+    handleRevsetSubmit()
+  }
+
+  function applyRevsetHistory(revset: string) {
+    revsetFilter = revset
+    submitRevsetFromUser()
+    revsetInputEl?.blur()
+  }
+
+  async function insertRevsetOperatorFromMenu(token: string) {
+    const edit = insertRevsetOperator(
+      revsetFilter,
+      token,
+      revsetInputEl?.selectionStart,
+      revsetInputEl?.selectionEnd,
+    )
+    revsetFilter = edit.value
+    closeRevsetPickers()
+    revsetHelpOpen = false
+    await tick()
+    revsetInputEl?.focus()
+    revsetInputEl?.setSelectionRange(edit.selectionStart, edit.selectionEnd)
+  }
+
+  async function moveRevsetHistory(delta: -1 | 1) {
+    if (revsetHistoryOptions.length === 0) return
+    revsetHelpOpen = false
+    revsetOperatorsOpen = false
+    revsetHistoryOpen = true
+    const next = moveHistoryIndex(revsetHistoryIndex, delta, revsetHistoryOptions.length)
+    revsetHistoryIndex = next
+    revsetFilter = revsetHistoryOptions[next]
+    await tick()
+    revsetInputEl?.focus()
+    revsetInputEl?.setSelectionRange(revsetFilter.length, revsetFilter.length)
+  }
+
   function clearRevsetFilter() {
     revsetFilter = ''
+    closeRevsetPickers()
     handleRevsetSubmit()
   }
 
@@ -2355,8 +2432,9 @@
 
   function applyRevsetExample(revset: string) {
     revsetHelpOpen = false
+    closeRevsetPickers()
     revsetFilter = revset
-    handleRevsetSubmit()
+    submitRevsetFromUser()
   }
 
   // Click-outside + Escape close for the help popover.
@@ -2366,6 +2444,33 @@
       if (e instanceof KeyboardEvent && e.key !== 'Escape') return
       if (e instanceof MouseEvent && revsetHelpPopoverEl?.contains(e.target as Node)) return
       revsetHelpOpen = false
+    }
+    const id = setTimeout(() => {
+      document.addEventListener('click', close)
+      document.addEventListener('keydown', close)
+    }, 0)
+    return () => {
+      clearTimeout(id)
+      document.removeEventListener('click', close)
+      document.removeEventListener('keydown', close)
+    }
+  })
+
+  $effect(() => {
+    const count = revsetHistoryOptions.length
+    if (count === 0) {
+      closeRevsetHistory()
+    } else if (revsetHistoryIndex >= count) {
+      revsetHistoryIndex = count - 1
+    }
+  })
+
+  $effect(() => {
+    if (!revsetHistoryOpen && !revsetOperatorsOpen) return
+    const close = (e: Event) => {
+      if (e instanceof KeyboardEvent && e.key !== 'Escape') return
+      if (e instanceof MouseEvent && revsetFilterBarEl?.contains(e.target as Node)) return
+      closeRevsetPickers()
     }
     const id = setTimeout(() => {
       document.addEventListener('click', close)
@@ -2676,6 +2781,14 @@
     if (inlineMode || mutating || activeView === 'merge' || activeView === 'doc') {
       setMessage({ kind: 'warning', text: 'Agent navigate ignored — finish or Esc current mode' })
       return
+    }
+    if (p.revset !== undefined) {
+      pendingNavScroll = null
+      switchToLogView()
+      revsetFilter = p.revset
+      const ok = await userRefresh(true)
+      if (!ok) return
+      if (inlineMode || mutating || activeView === 'merge' || activeView === 'doc') return
     }
     // comment_id → position resolution. Agents reference comments by id (the
     // only stable handle they have). Two stores, distinguished by the OTHER
@@ -3043,31 +3156,93 @@
                (bookmark click, visibility toggle, smart views) are direct assignments.
                Previously lived inside RevisionGraph with 4 callback props threading
                control back up; extracted to eliminate the ownership inversion. -->
-          <div class="revset-filter-bar">
+          <div class="revset-filter-bar" bind:this={revsetFilterBarEl}>
             <span class="revset-icon">$</span>
             <input
               bind:this={revsetInputEl}
               value={revsetFilter}
-              oninput={(e: Event) => { revsetFilter = (e.target as HTMLInputElement).value }}
+              oninput={(e: Event) => {
+                revsetFilter = (e.target as HTMLInputElement).value
+                revsetHistoryIndex = -1
+                if (revsetHistoryOptions.length > 0) revsetHistoryOpen = true
+              }}
+              onfocus={openRevsetHistory}
               class="revset-input"
               type="text"
               placeholder={configuredLogRevset || "revset filter (press / to focus)"}
               onkeydown={(e: KeyboardEvent) => {
                 if (e.key === 'Enter') {
                   e.preventDefault()
-                  handleRevsetSubmit()
+                  submitRevsetFromUser()
                   revsetInputEl?.blur()
                 } else if (e.key === 'Escape') {
                   e.preventDefault()
+                  if (revsetHistoryOpen) {
+                    closeRevsetHistory()
+                    return
+                  }
                   clearRevsetFilter()
                   revsetInputEl?.blur()
+                } else if (e.key === 'ArrowDown') {
+                  e.preventDefault()
+                  void moveRevsetHistory(1)
+                } else if (e.key === 'ArrowUp') {
+                  e.preventDefault()
+                  void moveRevsetHistory(-1)
                 }
               }}
             />
+            <button
+              class="revset-history"
+              class:active={revsetHistoryOpen}
+              disabled={revsetHistoryOptions.length === 0}
+              onclick={() => revsetHistoryOpen ? closeRevsetHistory() : openRevsetHistory()}
+              title="Revset history"
+            >⌄</button>
+            <button
+              class="revset-operators"
+              class:active={revsetOperatorsOpen}
+              onclick={() => {
+                revsetHelpOpen = false
+                closeRevsetHistory()
+                revsetOperatorsOpen = !revsetOperatorsOpen
+              }}
+              title="Revset operators"
+            >&amp;</button>
             {#if revsetFilter}
               <button class="revset-clear" onclick={clearRevsetFilter} title="Clear filter (Escape)">x</button>
             {/if}
-            <button class="revset-help" onclick={() => revsetHelpOpen = !revsetHelpOpen} title="Revset help">?</button>
+            <button class="revset-help" onclick={() => { closeRevsetPickers(); revsetHelpOpen = !revsetHelpOpen }} title="Revset help">?</button>
+            {#if revsetHistoryOpen && revsetHistoryOptions.length > 0}
+              <div class="revset-history-menu" role="listbox" aria-label="Revset history">
+                {#each revsetHistoryOptions as item, i (item)}
+                  <button
+                    class="revset-history-item"
+                    class:active={i === revsetHistoryIndex}
+                    role="option"
+                    aria-selected={i === revsetHistoryIndex}
+                    title={item}
+                    onmousedown={(e: MouseEvent) => e.preventDefault()}
+                    onclick={() => applyRevsetHistory(item)}
+                  >{item}</button>
+                {/each}
+              </div>
+            {/if}
+            {#if revsetOperatorsOpen}
+              <div class="revset-operator-menu" role="menu" aria-label="Revset operators">
+                {#each REVSET_OPERATORS as op (op.label)}
+                  <button
+                    class="revset-operator-item"
+                    title={op.description}
+                    onmousedown={(e: MouseEvent) => e.preventDefault()}
+                    onclick={() => void insertRevsetOperatorFromMenu(op.token)}
+                  >
+                    <span class="operator-token">{op.label}</span>
+                    <span class="operator-desc">{op.description}</span>
+                  </button>
+                {/each}
+              </div>
+            {/if}
             {#if revsetHelpOpen}
               <div class="revset-help-popover" bind:this={revsetHelpPopoverEl}>
                 {#snippet ex(revset: string)}
@@ -3078,6 +3253,18 @@
                 <p><b>See everything</b>: {@render ex('all()')} or {@render ex('::')} (capped at 500)</p>
                 <p class="help-examples">
                   Common: {@render ex('mine()')} · {@render ex('trunk()..@')} · {@render ex('ancestors(@, 20)')}
+                </p>
+                <p class="help-operators">
+                  <b>Operators</b>:
+                  {#each REVSET_OPERATORS as op (op.label)}
+                    <button
+                      class="help-ex help-operator"
+                      title={op.description}
+                      aria-label={op.description}
+                      onmousedown={(e: MouseEvent) => e.preventDefault()}
+                      onclick={() => void insertRevsetOperatorFromMenu(op.token)}
+                    >{op.label}</button>
+                  {/each}
                 </p>
               </div>
             {/if}
@@ -3624,6 +3811,124 @@
     color: var(--red);
   }
 
+  .revset-history,
+  .revset-operators {
+    background: transparent;
+    border: 1px solid var(--surface1);
+    border-radius: 3px;
+    color: var(--overlay0);
+    cursor: pointer;
+    font-family: inherit;
+    font-size: var(--fs-sm);
+    height: 20px;
+    line-height: 16px;
+    padding: 0 5px;
+    flex-shrink: 0;
+  }
+  .revset-history:hover:not(:disabled),
+  .revset-history.active,
+  .revset-operators:hover,
+  .revset-operators.active {
+    color: var(--amber);
+    border-color: var(--amber);
+    background: var(--surface0);
+  }
+  .revset-history:disabled {
+    cursor: default;
+    opacity: 0.35;
+  }
+
+  .revset-history-menu {
+    position: absolute;
+    top: calc(100% - 2px);
+    left: 26px;
+    right: 30px;
+    margin-top: 4px;
+    padding: 4px;
+    background: var(--mantle);
+    border: 1px solid var(--surface1);
+    border-radius: 5px;
+    box-shadow: 0 4px 16px rgba(0,0,0,0.25);
+    z-index: 11;
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+  }
+  .revset-history-item {
+    display: block;
+    width: 100%;
+    min-width: 0;
+    background: transparent;
+    color: var(--subtext0);
+    border: 0;
+    border-radius: 3px;
+    cursor: pointer;
+    font-family: var(--font-mono);
+    font-size: var(--fs-sm);
+    line-height: 1.35;
+    padding: 4px 6px;
+    text-align: left;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .revset-history-item:hover,
+  .revset-history-item.active {
+    background: var(--bg-selected);
+    color: var(--text);
+  }
+
+  .revset-operator-menu {
+    position: absolute;
+    top: calc(100% - 2px);
+    right: 4px;
+    margin-top: 4px;
+    width: min(420px, calc(100vw - 24px));
+    max-height: min(520px, calc(100vh - 110px));
+    overflow-y: auto;
+    padding: 4px;
+    background: var(--mantle);
+    border: 1px solid var(--surface1);
+    border-radius: 5px;
+    box-shadow: 0 4px 16px rgba(0,0,0,0.25);
+    z-index: 11;
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+  }
+  .revset-operator-item {
+    display: grid;
+    grid-template-columns: 58px 1fr;
+    align-items: center;
+    gap: 8px;
+    width: 100%;
+    min-width: 0;
+    background: transparent;
+    color: var(--subtext0);
+    border: 0;
+    border-radius: 3px;
+    cursor: pointer;
+    font-family: inherit;
+    font-size: var(--fs-sm);
+    line-height: 1.35;
+    padding: 4px 6px;
+    text-align: left;
+  }
+  .revset-operator-item:hover {
+    background: var(--bg-selected);
+    color: var(--text);
+  }
+  .operator-token {
+    color: var(--text);
+    font-family: var(--font-mono);
+    font-weight: 600;
+  }
+  .operator-desc {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
   .revset-help {
     background: transparent;
     border: 1px solid var(--surface1);
@@ -3685,7 +3990,21 @@
     border: 1px solid var(--surface1);
     padding: 0 3px;
   }
-  .help-examples { color: var(--subtext0); font-size: var(--fs-sm); }
+  .help-examples,
+  .help-operators {
+    color: var(--subtext0);
+    font-size: var(--fs-sm);
+  }
+  .help-operators {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 4px;
+  }
+  .help-operator {
+    min-width: 26px;
+    text-align: center;
+  }
 
   .panel-divider {
     width: 4px;

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -184,10 +184,11 @@ function notifyStaleWC(stale: boolean) {
 }
 
 // Agent-driven navigate subscribers. POST /api/navigate → SSE `nav` event with
-// {change_id?, file_path?, line?, comment_id?}. App scrolls the human's view
-// there. comment_id resolves to a {file_path, line} client-side via the
-// annotation/doc-comment stores when present (the agent only knows the id).
-export interface NavigatePayload { change_id?: string; file_path?: string; line?: number; comment_id?: string }
+// {revset?, change_id?, file_path?, line?, comment_id?}. App can replace the
+// graph filter before selecting the change. comment_id resolves to a
+// {file_path, line} client-side via the annotation/doc-comment stores when
+// present (the agent only knows the id).
+export interface NavigatePayload { change_id?: string; file_path?: string; line?: number; comment_id?: string; revset?: string }
 const navigateCallbacks = new Set<(p: NavigatePayload) => void>()
 function notifyNavigate(p: NavigatePayload) {
   for (const cb of navigateCallbacks) cb(p)

--- a/frontend/src/lib/revset-history.test.ts
+++ b/frontend/src/lib/revset-history.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest'
+import {
+  REVSET_OPERATORS,
+  insertRevsetOperator,
+  moveHistoryIndex,
+  normalizeRevset,
+  revsetHistoryItems,
+} from './revset-history'
+
+describe('revset history', () => {
+  it('normalizes submitted revsets', () => {
+    expect(normalizeRevset('  trunk()..@  ')).toBe('trunk()..@')
+  })
+
+  it('returns newest finite non-empty entries first', () => {
+    expect(revsetHistoryItems({
+      'mine()': 2,
+      '': 10,
+      'all()': 3,
+      'bad': Number.NaN,
+      'trunk()..@': 1,
+    })).toEqual(['all()', 'mine()', 'trunk()..@'])
+  })
+
+  it('filters by the current query and omits the exact current value', () => {
+    expect(revsetHistoryItems({
+      'main@origin..@': 3,
+      'trunk()..@': 2,
+      'mine()': 1,
+    }, 'main')).toEqual(['main@origin..@'])
+
+    expect(revsetHistoryItems({
+      'trunk()..@': 2,
+      'mine()': 1,
+    }, 'trunk()..@')).toEqual([])
+  })
+
+  it('caps entries to the requested limit', () => {
+    expect(revsetHistoryItems({ a: 1, b: 2, c: 3 }, '', 2)).toEqual(['c', 'b'])
+  })
+
+  it('moves the keyboard cursor with wrapping', () => {
+    expect(moveHistoryIndex(-1, 1, 3)).toBe(0)
+    expect(moveHistoryIndex(-1, -1, 3)).toBe(2)
+    expect(moveHistoryIndex(2, 1, 3)).toBe(0)
+    expect(moveHistoryIndex(0, -1, 3)).toBe(2)
+    expect(moveHistoryIndex(0, 1, 0)).toBe(-1)
+  })
+
+  it('exposes common revset operators', () => {
+    expect(REVSET_OPERATORS.map(op => op.label)).toEqual([
+      'f(x)',
+      'x-',
+      'x+',
+      'p:x',
+      'x::',
+      'x..',
+      '::x',
+      '..x',
+      'x::y',
+      'x..y',
+      '::',
+      '..',
+      '~x',
+      'x & y',
+      'x ~ y',
+      'x | y',
+    ])
+  })
+
+  it('inserts an operator at the current cursor', () => {
+    expect(insertRevsetOperator('trunk()@', ' | ', 7, 7)).toEqual({
+      value: 'trunk() | @',
+      selectionStart: 10,
+      selectionEnd: 10,
+    })
+  })
+
+  it('wraps the selected expression with grouping parens', () => {
+    expect(insertRevsetOperator('mine() & mutable()', '()', 9, 18)).toEqual({
+      value: 'mine() & (mutable())',
+      selectionStart: 20,
+      selectionEnd: 20,
+    })
+  })
+})

--- a/frontend/src/lib/revset-history.ts
+++ b/frontend/src/lib/revset-history.ts
@@ -1,0 +1,75 @@
+export const REVSET_HISTORY_LIMIT = 8
+
+export const REVSET_OPERATORS = [
+  { label: 'f(x)', token: '()', description: 'Function call or grouping parentheses' },
+  { label: 'x-', token: '-', description: 'Parents of x' },
+  { label: 'x+', token: '+', description: 'Children of x' },
+  { label: 'p:x', token: ':', description: 'String/date pattern or pattern alias p' },
+  { label: 'x::', token: '::', description: 'Descendants of x, including x' },
+  { label: 'x..', token: '..', description: 'Revisions that are not ancestors of x' },
+  { label: '::x', token: '::', description: 'Ancestors of x, including x' },
+  { label: '..x', token: '..', description: 'Ancestors of x, excluding root' },
+  { label: 'x::y', token: '::', description: 'Descendants of x that are ancestors of y' },
+  { label: 'x..y', token: '..', description: 'Ancestors of y that are not ancestors of x' },
+  { label: '::', token: '::', description: 'All visible commits' },
+  { label: '..', token: '..', description: 'All visible commits except root' },
+  { label: '~x', token: '~', description: 'Revisions that are not in x' },
+  { label: 'x & y', token: ' & ', description: 'Revisions that are in both x and y' },
+  { label: 'x ~ y', token: ' ~ ', description: 'Revisions that are in x but not y' },
+  { label: 'x | y', token: ' | ', description: 'Revisions that are in either x or y' },
+] as const
+
+export function normalizeRevset(revset: string): string {
+  return revset.trim()
+}
+
+export function revsetHistoryItems(
+  entries: Record<string, number>,
+  query = '',
+  limit = REVSET_HISTORY_LIMIT,
+): string[] {
+  const needle = normalizeRevset(query).toLowerCase()
+  return Object.entries(entries)
+    .filter(([revset, ts]) =>
+      normalizeRevset(revset) !== '' &&
+      Number.isFinite(ts) &&
+      (needle === '' || revset.toLowerCase().includes(needle)) &&
+      revset.toLowerCase() !== needle
+    )
+    .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
+    .slice(0, limit)
+    .map(([revset]) => revset)
+}
+
+export function moveHistoryIndex(current: number, delta: -1 | 1, count: number): number {
+  if (count <= 0) return -1
+  if (current < 0) return delta > 0 ? 0 : count - 1
+  return (current + delta + count) % count
+}
+
+function clampTextIndex(index: number | null | undefined, fallback: number, length: number): number {
+  if (index === null || index === undefined || !Number.isFinite(index)) return fallback
+  return Math.max(0, Math.min(length, index))
+}
+
+export function insertRevsetOperator(
+  value: string,
+  token: string,
+  selectionStart: number | null | undefined = value.length,
+  selectionEnd: number | null | undefined = selectionStart,
+): { value: string; selectionStart: number; selectionEnd: number } {
+  const start = clampTextIndex(selectionStart, value.length, value.length)
+  const end = clampTextIndex(selectionEnd, start, value.length)
+  const from = Math.min(start, end)
+  const to = Math.max(start, end)
+
+  if (token === '()') {
+    const next = `${value.slice(0, from)}(${value.slice(from, to)})${value.slice(to)}`
+    const cursor = to > from ? to + 2 : from + 1
+    return { value: next, selectionStart: cursor, selectionEnd: cursor }
+  }
+
+  const next = `${value.slice(0, from)}${token}${value.slice(to)}`
+  const cursor = from + token.length
+  return { value: next, selectionStart: cursor, selectionEnd: cursor }
+}

--- a/internal/api/agent_api.md
+++ b/internal/api/agent_api.md
@@ -306,6 +306,14 @@ against its loaded comment stores and scrolls to that thread. If the id isn't
 loaded in the user's current view, nothing happens. Combine with `change_id`
 or `file_path` if you want a fallback scroll target.
 
+To change the visible graph filter first, include `revset`. A revset-only
+payload updates the filter without selecting a revision; combining `revset`
+with `change_id` reloads the graph and then selects that change:
+
+```jsonc
+{"revset": "trunk()..@", "change_id": "wqnwkozp"}
+```
+
 ## Read the user's current view
 
 ```

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -579,6 +579,9 @@ type navigateRequest struct {
 	ChangeID string `json:"change_id,omitempty"`
 	FilePath string `json:"file_path,omitempty"`
 	Line     int    `json:"line,omitempty"`
+	// Revset, when present, asks the frontend to replace the graph filter
+	// before selecting ChangeID. An empty string intentionally clears the filter.
+	Revset *string `json:"revset,omitempty"`
 	// CommentID is passed through to the frontend untouched — the server has
 	// no view of the comment store's positions; the frontend resolves the id
 	// to a scroll target against its loaded annotation/doc-comment stores.
@@ -600,14 +603,19 @@ func (s *Server) handleNavigate(w http.ResponseWriter, r *http.Request) {
 		s.writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
-	if req.ChangeID == "" && req.FilePath == "" && req.CommentID == "" {
-		s.writeError(w, http.StatusBadRequest, "change_id, file_path, or comment_id required")
+	if req.ChangeID == "" && req.FilePath == "" && req.CommentID == "" && req.Revset == nil {
+		s.writeError(w, http.StatusBadRequest, "change_id, file_path, comment_id, or revset required")
 		return
 	}
 	// Cap before broadcast — payload is copied into every subscriber's chan
 	// buffer; an oversized field is a cheap amplification vector. 4k is far
-	// beyond any real change_id (~12 chars) or repo-relative path.
-	if len(req.ChangeID) > 256 || len(req.FilePath) > 4096 || len(req.CommentID) > 256 {
+	// beyond any real change_id (~12 chars), repo-relative path, or practical
+	// revset filter.
+	revsetLen := 0
+	if req.Revset != nil {
+		revsetLen = len(*req.Revset)
+	}
+	if len(req.ChangeID) > 256 || len(req.FilePath) > 4096 || len(req.CommentID) > 256 || revsetLen > 4096 {
 		s.writeError(w, http.StatusBadRequest, "field too long")
 		return
 	}
@@ -934,8 +942,8 @@ func (q rebaseRequest) build() (jj.CommandArgs, error) {
 }
 
 type squashRequest struct {
-	Revisions   []string `json:"revisions"`
-	Destination string   `json:"destination"`
+	Revisions       []string `json:"revisions"`
+	Destination     string   `json:"destination"`
 	Files           []string `json:"files"`
 	KeepEmptied     bool     `json:"keep_emptied"`
 	IgnoreImmutable bool     `json:"ignore_immutable"`

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -3883,7 +3883,7 @@ func TestHandleNavigate(t *testing.T) {
 	defer unsub()
 
 	w := httptest.NewRecorder()
-	srv.Mux.ServeHTTP(w, jsonPost("/api/navigate", []byte(`{"change_id":"abc","file_path":"src/a.go","line":42}`)))
+	srv.Mux.ServeHTTP(w, jsonPost("/api/navigate", []byte(`{"change_id":"abc","file_path":"src/a.go","line":42,"revset":"trunk()..@"}`)))
 	require.Equal(t, http.StatusOK, w.Code)
 
 	select {
@@ -3894,6 +3894,8 @@ func TestHandleNavigate(t *testing.T) {
 		assert.Equal(t, "abc", p.ChangeID)
 		assert.Equal(t, "src/a.go", p.FilePath)
 		assert.Equal(t, 42, p.Line)
+		require.NotNil(t, p.Revset)
+		assert.Equal(t, "trunk()..@", *p.Revset)
 	case <-time.After(100 * time.Millisecond):
 		t.Fatal("navigate not broadcast")
 	}
@@ -3935,6 +3937,32 @@ func TestHandleNavigate_BadRequest(t *testing.T) {
 			srv.Mux.ServeHTTP(w, jsonPost("/api/navigate", []byte(tc.body)))
 			assert.Equal(t, http.StatusBadRequest, w.Code)
 		})
+	}
+}
+
+func TestHandleNavigateRevsetOnly(t *testing.T) {
+	runner := testutil.NewMockRunner(t)
+	defer runner.Verify()
+	srv := newTestServer(runner)
+	srv.Watcher = &Watcher{subs: make(map[chan sseEvent]struct{}), srv: srv}
+
+	ch, unsub := srv.Watcher.subscribe()
+	defer unsub()
+
+	w := httptest.NewRecorder()
+	srv.Mux.ServeHTTP(w, jsonPost("/api/navigate", []byte(`{"revset":"@"}`)))
+	require.Equal(t, http.StatusOK, w.Code)
+
+	select {
+	case msg := <-ch:
+		require.Equal(t, evNameNav, msg.name)
+		var p navigateRequest
+		require.NoError(t, json.Unmarshal([]byte(msg.data), &p))
+		require.NotNil(t, p.Revset)
+		assert.Equal(t, "@", *p.Revset)
+		assert.Empty(t, p.ChangeID)
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("navigate not broadcast")
 	}
 }
 


### PR DESCRIPTION
## What this adds

This PR makes LightJJ revsets easier to use from both the UI and agent automation.

For users, the revset input now keeps a local searchable history, so previously used revsets can be recalled instead of retyped. This is useful when switching between focused stack views like `trunk()..@`, wider archaeology views, and custom cleanup revsets.

For agents, `/api/navigate` now accepts a `revset` field. A revset-only payload changes the visible graph filter; a payload with both `revset` and `change_id` applies the graph filter first and then selects the target change. That lets an agent reliably steer the browser to a change even when the current graph would otherwise hide it.

The LightJJ skill docs are updated with the supported revset-steering patterns.

## Changes
- add revset history/search helpers and tests
- wire revset history into the frontend revset control
- extend navigate payload typing and backend validation for `revset`
- apply agent-provided revsets before selecting changes in the frontend
- document revset steering in the agent skill and API docs

## Verification
- pnpm --dir frontend exec vitest run App.interactions.test.ts src/lib/revset-history.test.ts
- go test ./internal/api -run TestHandleNavigate -count=1

## Scope
Clean two-commit PR. No `.gitignore`, `.beads`, doc-mode, or editor-refactor changes are included.