### PR TITLE
Allow agents to steer LightJJ revsets

### DIFF
--- a/cmd/lightjj/SKILL.md
+++ b/cmd/lightjj/SKILL.md
@@ -72,6 +72,12 @@ lightjj api POST /tab/0/api/doc-comments @comment.json
 lightjj api POST /tab/0/api/navigate '{"file_path":"src/main.go","line":42}'
 lightjj api POST /tab/0/api/navigate '{"change_id":"xyzabc","comment_id":"a1b2c3"}'
 
+# Set the visible revset filter. A revset-only payload changes the graph
+# without selecting a revision; combine revset + change_id when the target
+# may not be visible under the user's current filter.
+lightjj api POST /tab/0/api/navigate '{"revset":"trunk()..@"}'
+lightjj api POST /tab/0/api/navigate '{"revset":"mutable()","change_id":"xyzabc"}'
+
 # Read inline review comments (annotations) on a change. Note: camelCase param.
 lightjj api GET '/tab/0/api/annotations?changeId=xyzabc'
 
@@ -81,6 +87,41 @@ lightjj api POST /tab/0/api/annotations '{"id":"a1","changeId":"xyzabc",
   "filePath":"src/main.go","lineNum":42,"lineContent":"func main() {",
   "comment":"missing error check","severity":"suggestion","author":"agent-name"}'
 ```
+
+## Driving the revset view
+
+Use `/api/navigate` when the user asks you to change what LightJJ is showing.
+Do not run `jj` just to answer "can you set the revset?" — steer the running
+viewer through the API so the browser and agent stay in sync.
+
+```bash
+# Show the current working stack relative to trunk
+lightjj api POST /tab/0/api/navigate '{"revset":"trunk()..@"}'
+
+# Show all mutable work, including alternate heads
+lightjj api POST /tab/0/api/navigate '{"revset":"mutable()"}'
+
+# Show the default jj-ish context used by the UI preset
+lightjj api POST /tab/0/api/navigate '{"revset":"present(@) | ancestors(immutable_heads().., 2) | present(trunk())"}'
+
+# If selecting a commit that may be outside the current view, set revset and
+# change_id together. The frontend applies the revset first, then selects.
+lightjj api POST /tab/0/api/navigate '{"revset":"all() ~ root()","change_id":"xyzabc"}'
+```
+
+After steering, verify what the browser accepted:
+
+```bash
+lightjj api GET /tab/0/api/focus
+lightjj api GET '/tab/0/api/log?revset=trunk()..@'
+```
+
+Prefer narrow revsets for user-facing cleanup work:
+
+- `trunk()..@` — current working-copy stack relative to trunk.
+- `mutable()` — local mutable heads and workspace work.
+- `all() ~ root()` — archaeology only; it will surface remote branches and
+  stale artifacts that are not part of the current working view.
 
 ## Review loop
 

--- a/cmd/lightjj/SKILL.md
+++ b/cmd/lightjj/SKILL.md
@@ -106,22 +106,23 @@ lightjj api POST /tab/0/api/navigate '{"revset":"present(@) | ancestors(immutabl
 
 # If selecting a commit that may be outside the current view, set revset and
 # change_id together. The frontend applies the revset first, then selects.
-lightjj api POST /tab/0/api/navigate '{"revset":"all() ~ root()","change_id":"xyzabc"}'
+lightjj api POST /tab/0/api/navigate '{"revset":"xyzabc | present(@) | trunk()","change_id":"xyzabc"}'
 ```
 
-After steering, verify what the browser accepted:
+After steering, verify the graph with the same revset. For combined navigation,
+use focus only to confirm the selected change; focus does not report the revset:
 
 ```bash
-lightjj api GET /tab/0/api/focus
 lightjj api GET '/tab/0/api/log?revset=trunk()..@'
+lightjj api GET /tab/0/api/focus
 ```
 
 Prefer narrow revsets for user-facing cleanup work:
 
 - `trunk()..@` — current working-copy stack relative to trunk.
 - `mutable()` — local mutable heads and workspace work.
-- `all() ~ root()` — archaeology only; it will surface remote branches and
-  stale artifacts that are not part of the current working view.
+- `<change_id> | present(@) | trunk()` — a target change with enough working
+  context for focused review.
 
 ## Review loop
 

--- a/frontend/src/App.interactions.test.ts
+++ b/frontend/src/App.interactions.test.ts
@@ -174,6 +174,16 @@ describe('App.svelte interactions', () => {
     await waitFor(() => qs('.message-text')?.textContent?.includes('not in current revset') === true)
     expect(selectedEntry()).toBe('0')
   })
+
+  it('agent navigate can apply a revset before selecting a change', async () => {
+    await mountApp()
+
+    triggerNavigate({ revset: 'trunk()..@', change_id: 'cmid' })
+
+    await waitFor(() => selectedEntry() === '1')
+    expect(calls.some(c => c.method === 'log' && c.args[0] === 'trunk()..@')).toBe(true)
+    expect((qs('.revset-input') as HTMLInputElement | null)?.value).toBe('trunk()..@')
+  })
 })
 
 // ── Staleness model + identity-keyed cursor ─────────────────────────────────

--- a/frontend/src/App.interactions.test.ts
+++ b/frontend/src/App.interactions.test.ts
@@ -178,11 +178,15 @@ describe('App.svelte interactions', () => {
   it('agent navigate can apply a revset before selecting a change', async () => {
     await mountApp()
 
+    await press(' ')
+    expect(qs('.graph-row.checked')).not.toBeNull()
+
     triggerNavigate({ revset: 'trunk()..@', change_id: 'cmid' })
 
     await waitFor(() => selectedEntry() === '1')
     expect(calls.some(c => c.method === 'log' && c.args[0] === 'trunk()..@')).toBe(true)
     expect((qs('.revset-input') as HTMLInputElement | null)?.value).toBe('trunk()..@')
+    expect(qs('.graph-row.checked')).toBeNull()
   })
 })
 

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -2677,6 +2677,14 @@
       setMessage({ kind: 'warning', text: 'Agent navigate ignored — finish or Esc current mode' })
       return
     }
+    if (p.revset !== undefined) {
+      pendingNavScroll = null
+      switchToLogView()
+      revsetFilter = p.revset
+      const ok = await userRefresh(true)
+      if (!ok) return
+      if (inlineMode || mutating || activeView === 'merge' || activeView === 'doc') return
+    }
     // comment_id → position resolution. Agents reference comments by id (the
     // only stable handle they have). Two stores, distinguished by the OTHER
     // field the agent supplies:

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -2341,7 +2341,7 @@
     diff.reset()
     files.reset()
     clearChecks()
-    userRefresh(true)
+    return userRefresh(true)
   }
 
   function clearRevsetFilter() {
@@ -2681,7 +2681,7 @@
       pendingNavScroll = null
       switchToLogView()
       revsetFilter = p.revset
-      const ok = await userRefresh(true)
+      const ok = await handleRevsetSubmit()
       if (!ok) return
       if (inlineMode || mutating || activeView === 'merge' || activeView === 'doc') return
     }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -184,10 +184,11 @@ function notifyStaleWC(stale: boolean) {
 }
 
 // Agent-driven navigate subscribers. POST /api/navigate → SSE `nav` event with
-// {change_id?, file_path?, line?, comment_id?}. App scrolls the human's view
-// there. comment_id resolves to a {file_path, line} client-side via the
-// annotation/doc-comment stores when present (the agent only knows the id).
-export interface NavigatePayload { change_id?: string; file_path?: string; line?: number; comment_id?: string }
+// {revset?, change_id?, file_path?, line?, comment_id?}. App can replace the
+// graph filter before selecting the change. comment_id resolves to a
+// {file_path, line} client-side via the annotation/doc-comment stores when
+// present (the agent only knows the id).
+export interface NavigatePayload { change_id?: string; file_path?: string; line?: number; comment_id?: string; revset?: string }
 const navigateCallbacks = new Set<(p: NavigatePayload) => void>()
 function notifyNavigate(p: NavigatePayload) {
   for (const cb of navigateCallbacks) cb(p)

--- a/internal/api/agent_api.md
+++ b/internal/api/agent_api.md
@@ -306,6 +306,14 @@ against its loaded comment stores and scrolls to that thread. If the id isn't
 loaded in the user's current view, nothing happens. Combine with `change_id`
 or `file_path` if you want a fallback scroll target.
 
+To change the visible graph filter first, include `revset`. A revset-only
+payload updates the filter without selecting a revision; combining `revset`
+with `change_id` reloads the graph and then selects that change:
+
+```jsonc
+{"revset": "trunk()..@", "change_id": "wqnwkozp"}
+```
+
 ## Read the user's current view
 
 ```

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -579,6 +579,9 @@ type navigateRequest struct {
 	ChangeID string `json:"change_id,omitempty"`
 	FilePath string `json:"file_path,omitempty"`
 	Line     int    `json:"line,omitempty"`
+	// Revset, when present, asks the frontend to replace the graph filter
+	// before selecting ChangeID. An empty string intentionally clears the filter.
+	Revset *string `json:"revset,omitempty"`
 	// CommentID is passed through to the frontend untouched — the server has
 	// no view of the comment store's positions; the frontend resolves the id
 	// to a scroll target against its loaded annotation/doc-comment stores.
@@ -600,14 +603,19 @@ func (s *Server) handleNavigate(w http.ResponseWriter, r *http.Request) {
 		s.writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
-	if req.ChangeID == "" && req.FilePath == "" && req.CommentID == "" {
-		s.writeError(w, http.StatusBadRequest, "change_id, file_path, or comment_id required")
+	if req.ChangeID == "" && req.FilePath == "" && req.CommentID == "" && req.Revset == nil {
+		s.writeError(w, http.StatusBadRequest, "change_id, file_path, comment_id, or revset required")
 		return
 	}
 	// Cap before broadcast — payload is copied into every subscriber's chan
 	// buffer; an oversized field is a cheap amplification vector. 4k is far
-	// beyond any real change_id (~12 chars) or repo-relative path.
-	if len(req.ChangeID) > 256 || len(req.FilePath) > 4096 || len(req.CommentID) > 256 {
+	// beyond any real change_id (~12 chars), repo-relative path, or practical
+	// revset filter.
+	revsetLen := 0
+	if req.Revset != nil {
+		revsetLen = len(*req.Revset)
+	}
+	if len(req.ChangeID) > 256 || len(req.FilePath) > 4096 || len(req.CommentID) > 256 || revsetLen > 4096 {
 		s.writeError(w, http.StatusBadRequest, "field too long")
 		return
 	}
@@ -934,8 +942,8 @@ func (q rebaseRequest) build() (jj.CommandArgs, error) {
 }
 
 type squashRequest struct {
-	Revisions   []string `json:"revisions"`
-	Destination string   `json:"destination"`
+	Revisions       []string `json:"revisions"`
+	Destination     string   `json:"destination"`
 	Files           []string `json:"files"`
 	KeepEmptied     bool     `json:"keep_emptied"`
 	IgnoreImmutable bool     `json:"ignore_immutable"`

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -3883,6 +3883,32 @@ func TestHandleNavigate(t *testing.T) {
 	defer unsub()
 
 	w := httptest.NewRecorder()
+	srv.Mux.ServeHTTP(w, jsonPost("/api/navigate", []byte(`{"change_id":"abc","file_path":"src/a.go","line":42}`)))
+	require.Equal(t, http.StatusOK, w.Code)
+
+	select {
+	case msg := <-ch:
+		require.Equal(t, evNameNav, msg.name)
+		var p navigateRequest
+		require.NoError(t, json.Unmarshal([]byte(msg.data), &p))
+		assert.Equal(t, "abc", p.ChangeID)
+		assert.Equal(t, "src/a.go", p.FilePath)
+		assert.Equal(t, 42, p.Line)
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("navigate not broadcast")
+	}
+}
+
+func TestHandleNavigateWithRevsetAndChange(t *testing.T) {
+	runner := testutil.NewMockRunner(t)
+	defer runner.Verify()
+	srv := newTestServer(runner)
+	srv.Watcher = &Watcher{subs: make(map[chan sseEvent]struct{}), srv: srv}
+
+	ch, unsub := srv.Watcher.subscribe()
+	defer unsub()
+
+	w := httptest.NewRecorder()
 	srv.Mux.ServeHTTP(w, jsonPost("/api/navigate", []byte(`{"change_id":"abc","file_path":"src/a.go","line":42,"revset":"trunk()..@"}`)))
 	require.Equal(t, http.StatusOK, w.Code)
 

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -3883,7 +3883,7 @@ func TestHandleNavigate(t *testing.T) {
 	defer unsub()
 
 	w := httptest.NewRecorder()
-	srv.Mux.ServeHTTP(w, jsonPost("/api/navigate", []byte(`{"change_id":"abc","file_path":"src/a.go","line":42}`)))
+	srv.Mux.ServeHTTP(w, jsonPost("/api/navigate", []byte(`{"change_id":"abc","file_path":"src/a.go","line":42,"revset":"trunk()..@"}`)))
 	require.Equal(t, http.StatusOK, w.Code)
 
 	select {
@@ -3894,6 +3894,8 @@ func TestHandleNavigate(t *testing.T) {
 		assert.Equal(t, "abc", p.ChangeID)
 		assert.Equal(t, "src/a.go", p.FilePath)
 		assert.Equal(t, 42, p.Line)
+		require.NotNil(t, p.Revset)
+		assert.Equal(t, "trunk()..@", *p.Revset)
 	case <-time.After(100 * time.Millisecond):
 		t.Fatal("navigate not broadcast")
 	}
@@ -3935,6 +3937,32 @@ func TestHandleNavigate_BadRequest(t *testing.T) {
 			srv.Mux.ServeHTTP(w, jsonPost("/api/navigate", []byte(tc.body)))
 			assert.Equal(t, http.StatusBadRequest, w.Code)
 		})
+	}
+}
+
+func TestHandleNavigateRevsetOnly(t *testing.T) {
+	runner := testutil.NewMockRunner(t)
+	defer runner.Verify()
+	srv := newTestServer(runner)
+	srv.Watcher = &Watcher{subs: make(map[chan sseEvent]struct{}), srv: srv}
+
+	ch, unsub := srv.Watcher.subscribe()
+	defer unsub()
+
+	w := httptest.NewRecorder()
+	srv.Mux.ServeHTTP(w, jsonPost("/api/navigate", []byte(`{"revset":"@"}`)))
+	require.Equal(t, http.StatusOK, w.Code)
+
+	select {
+	case msg := <-ch:
+		require.Equal(t, evNameNav, msg.name)
+		var p navigateRequest
+		require.NoError(t, json.Unmarshal([]byte(msg.data), &p))
+		require.NotNil(t, p.Revset)
+		assert.Equal(t, "@", *p.Revset)
+		assert.Empty(t, p.ChangeID)
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("navigate not broadcast")
 	}
 }
 


### PR DESCRIPTION
## What this adds

This PR lets automation steer the visible LightJJ graph before selecting a change.

Agents can now call `/api/navigate` with a `revset` field. A revset-only payload changes the browser graph filter. A payload with both `revset` and `change_id` applies the graph filter first, reloads the graph, and then selects the requested change. This matters when the change an agent wants to show is hidden by the user’s current revset.

The LightJJ agent skill is updated with the supported revset-steering commands and guidance about using narrow revsets for review work.

## Changes
- extend navigate payload typing with `revset`
- validate and broadcast revset navigate payloads from the API
- apply agent-provided revsets in the frontend before selecting a change
- add frontend and backend tests for revset navigation
- document the workflow in `cmd/lightjj/SKILL.md` and `internal/api/agent_api.md`

## Verification
- pnpm --dir frontend exec vitest run App.interactions.test.ts
- go test ./internal/api -run TestHandleNavigate -count=1